### PR TITLE
move geckodriver.exe to SCRIPTS

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,7 +5,6 @@ cargo build --release --verbose
 IF ERRORLEVEL 1 EXIT /B 1
 cargo install --bin %PKG_NAME% --root %PREFIX%
 IF ERRORLEVEL 1 EXIT /B 1
-IF NOT EXIST MKDIR %LIBRARY_BIN%
-MOVE %PREFIX%\%PKG_NAME%.exe %LIBRARY_BIN%\
+MOVE %PREFIX%\%PKG_NAME%.exe %SCRIPTS%\%PKG_NAME%.exe
 IF ERRORLEVEL 1 EXIT /B 1
 DEL /F /Q %PREFIX%\.crates.toml

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,6 +5,7 @@ cargo build --release --verbose
 IF ERRORLEVEL 1 EXIT /B 1
 cargo install --bin %PKG_NAME% --root %PREFIX%
 IF ERRORLEVEL 1 EXIT /B 1
+MKDIR %LIBRARY_BIN%
 MOVE %PREFIX%\%PKG_NAME%.exe %LIBRARY_BIN%\
 IF ERRORLEVEL 1 EXIT /B 1
 DEL /F /Q %PREFIX%\.crates.toml

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,7 +5,7 @@ cargo build --release --verbose
 IF ERRORLEVEL 1 EXIT /B 1
 cargo install --bin %PKG_NAME% --root %PREFIX%
 IF ERRORLEVEL 1 EXIT /B 1
-MKDIR %LIBRARY_BIN%
+IF NOT EXIST MKDIR %LIBRARY_BIN%
 MOVE %PREFIX%\%PKG_NAME%.exe %LIBRARY_BIN%\
 IF ERRORLEVEL 1 EXIT /B 1
 DEL /F /Q %PREFIX%\.crates.toml

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,4 +5,6 @@ cargo build --release --verbose
 IF ERRORLEVEL 1 EXIT /B 1
 cargo install --bin %PKG_NAME% --root %PREFIX%
 IF ERRORLEVEL 1 EXIT /B 1
+MOVE %PREFIX%\%PKG_NAME%.exe %LIBRARY_BIN%\
+IF ERRORLEVEL 1 EXIT /B 1
 DEL /F /Q %PREFIX%\.crates.toml

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,6 +5,6 @@ cargo build --release --verbose
 IF ERRORLEVEL 1 EXIT /B 1
 cargo install --bin %PKG_NAME% --root %PREFIX%
 IF ERRORLEVEL 1 EXIT /B 1
-MOVE %PREFIX%\%PKG_NAME%.exe %SCRIPTS%\%PKG_NAME%.exe
+MOVE %PREFIX%\bin\%PKG_NAME%.exe %SCRIPTS%\%PKG_NAME%.exe
 IF ERRORLEVEL 1 EXIT /B 1
 DEL /F /Q %PREFIX%\.crates.toml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 0bee8be4841147528c41417e4eb1f44eaddd7aa16b267d6237ec2abafecf71b2
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win and vc!=14]
   msvc_compiler: 14.0  # [win]
 


### PR DESCRIPTION
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

Windows build was ending up in `%PREFIX%\bin%, which is not added to `%PATH%` on activation!